### PR TITLE
Implement ldb database functionality for optional addr index. 

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -19,7 +19,7 @@ var (
 	ignoreDbTypes = map[string]bool{"createopenfail": true}
 )
 
-// testNewestShaEmpty ensures the NewestSha returns the values expected by
+// testNewestShaEmpty ensures that NewestSha returns the values expected by
 // the interface contract.
 func testNewestShaEmpty(t *testing.T, db btcdb.Db) {
 	sha, height, err := db.NewestSha()

--- a/ldb/block.go
+++ b/ldb/block.go
@@ -290,3 +290,41 @@ func (db *LevelDb) NewestSha() (rsha *btcwire.ShaHash, rblkid int64, err error) 
 
 	return &sha, db.lastBlkIdx, nil
 }
+
+// fetchAddrIndexTip returns the last block height and block sha to be indexed.
+// Meta-data about the address tip is currently cached in memory, and will be
+// updated accordingly by functions that modify the state. This function is
+// used on start up to load the info into memory. Callers will use the public
+// version of this function below, which returns our cached copy.
+func (db *LevelDb) fetchAddrIndexTip() (*btcwire.ShaHash, int64, error) {
+	db.dbLock.Lock()
+	defer db.dbLock.Unlock()
+
+	data, err := db.lDb.Get(addrIndexMetaDataKey, db.ro)
+	if err != nil {
+		return &btcwire.ShaHash{}, -1, btcdb.ErrAddrIndexDoesNotExist
+	}
+
+	var blkSha btcwire.ShaHash
+	blkSha.SetBytes(data[0:32])
+
+	blkHeight := binary.LittleEndian.Uint64(data[32:])
+
+	return &blkSha, int64(blkHeight), nil
+}
+
+// FetchAddrIndexTip returns the hash and block height of the most recent
+// block whose transactions have been indexed by address. It will return
+// ErrAddrIndexDoesNotExist along with a zero hash, and -1 if the
+// addrindex hasn't yet been built up.
+func (db *LevelDb) FetchAddrIndexTip() (*btcwire.ShaHash, int64, error) {
+	db.dbLock.Lock()
+	defer db.dbLock.Unlock()
+
+	if db.lastAddrIndexBlkIdx == -1 {
+		return &btcwire.ShaHash{}, -1, btcdb.ErrAddrIndexDoesNotExist
+	}
+	sha := db.lastAddrIndexBlkSha
+
+	return &sha, db.lastAddrIndexBlkIdx, nil
+}

--- a/ldb/boundary_test.go
+++ b/ldb/boundary_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/btcsuite/btcwire"
 )
 
-// we need to test for empty databas and make certain it returns proper value
+// we need to test for an empty database and make certain it returns the proper
+// values
 
 func TestEmptyDB(t *testing.T) {
 

--- a/ldb/dup_test.go
+++ b/ldb/dup_test.go
@@ -110,7 +110,7 @@ out:
 		lastSha = blkSha
 	}
 
-	// genrate a new block based on the last sha
+	// generate a new block based on the last sha
 	// these block are not verified, so there are a bunch of garbage fields
 	// in the 'generated' block.
 

--- a/ldb/insertremove_test.go
+++ b/ldb/insertremove_test.go
@@ -66,7 +66,7 @@ endtest:
 	for height := int64(0); height < int64(len(blocks)); height++ {
 
 		block := blocks[height]
-		// look up inputs to this x
+		// look up inputs to this tx
 		mblock := block.MsgBlock()
 		var txneededList []*btcwire.ShaHash
 		var txlookupList []*btcwire.ShaHash

--- a/memdb/memdb.go
+++ b/memdb/memdb.go
@@ -698,6 +698,31 @@ func (db *MemDb) NewestSha() (*btcwire.ShaHash, int64, error) {
 	return &blockSha, int64(numBlocks - 1), nil
 }
 
+// FetchAddrIndexTip isn't currently implemented. This is a part of the
+// btcdb.Db interface implementation.
+func (db *MemDb) FetchAddrIndexTip() (*btcwire.ShaHash, int64, error) {
+	return nil, 0, btcdb.ErrNotImplemented
+}
+
+// UpdateAddrIndexForBlock isn't currently implemented. This is a part of the
+// btcdb.Db interface implementation.
+func (db *MemDb) UpdateAddrIndexForBlock(*btcwire.ShaHash, int64,
+	btcdb.BlockAddrIndex) error {
+	return btcdb.ErrNotImplemented
+}
+
+// FetchTxsForAddr isn't currently implemented. This is a part of the btcdb.Db
+// interface implementation.
+func (db *MemDb) FetchTxsForAddr(btcutil.Address, int, int) ([]*btcdb.TxListReply, error) {
+	return nil, btcdb.ErrNotImplemented
+}
+
+// DeleteAddrIndex isn't currently implemented. This is a part of the btcdb.Db
+// interface implementation.
+func (db *MemDb) DeleteAddrIndex() error {
+	return btcdb.ErrNotImplemented
+}
+
 // RollbackClose discards the recent database changes to the previously saved
 // data at last Sync and closes the database.  This is part of the btcdb.Db
 // interface implementation.


### PR DESCRIPTION
This pull request alters the `btcdb.db` interface, adding new functions for accessing/updating/deleting the optional address index. For now, only the `ldb` driver implements the newly defined functions. `memdb` has also been altered, but only to supply skeleton functions in order for the package to conform to the new `btcdb` interface (won't compile otherwise). Additionally this PR makes progress towards completion of conformal/btcd#190. Subsequent PR's dependant upon this one will be opened across: `btcd` + `btcjson` + `btcrpcclient`, ultimately fully implementing `btcd`'s new optional `addrindex`. 

In order to provide functionality for storage of a new address-based transaction index, the following functions have been added to the `btcdb`, `Db` interface:
  ```
  type Db interface {
      ....
      FetchAddrIndexTip() (sha *btcwire.ShaHash, height int64, err error)
      UpdateAddrIndexForBlock(blkSha *btcwire.ShaHash, blkHeight int64, addrIndex *BlockAddrIndex) error
      FetchTxsForAddr(addr *btcutil.Address, skip int, limit int) ([]*TxListReply, error)
      DeleteAddrIndex() error
  }
  ```

Along with a helper type-def:
  * ```type BlockAddrIndex map[[ripemd160.Size]byte][]*btcwire.TxLoc```

A single entry in the new optional index takes up 38-bytes raw, and is layed out like the following:
  ```
       ----------------------------------------------------------------------
       | Prefix  | Hash160  | BlkHeight | Tx Offset | Tx Size |
       ----------------------------------------------------------------------
       | 2 bytes | 20 bytes |  8 bytes  |  4 bytes  | 4 bytes |
       ----------------------------------------------------------------------
  ````

Each index maps a `hash160` to a transaction locator object (offset and size within block). Indexes are stored purely in the key (leaving blank bytes for the value), to make it easy to seek and limit the number of transactions returned via iterators. An ability to `skip` and `limit` the number of returned transactions is also required to properly implement the `searchrawtransaction` RPC. 